### PR TITLE
feat: Pajbot banphrase check

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -114,7 +114,7 @@ def raid_event():
                                     'current_experience': -(((db(opt.USERS).find_one_by_id(user)['user_level']+1)**2)*10)
                                 }})
                             level_up_users.append(user)
-                    level_up_names = util.get_display_name(0, level_up_users)
+                    level_up_names = util.sanitize_display_name(channel[0], 0, util.get_display_name(0, level_up_users))
                     if level_up_names:
                         i = 1
                         for user in level_up_names[::5]:

--- a/bot.py
+++ b/bot.py
@@ -114,7 +114,7 @@ def raid_event():
                                     'current_experience': -(((db(opt.USERS).find_one_by_id(user)['user_level']+1)**2)*10)
                                 }})
                             level_up_users.append(user)
-                    level_up_names = util.sanitize_display_name(channel[0], None, util.get_display_name(None, level_up_users))
+                    level_up_names = util.sanitize_display_names(channel[0], util.get_display_name(None, level_up_users))
                     if level_up_names:
                         i = 1
                         for user in level_up_names[::5]:

--- a/bot.py
+++ b/bot.py
@@ -114,7 +114,7 @@ def raid_event():
                                     'current_experience': -(((db(opt.USERS).find_one_by_id(user)['user_level']+1)**2)*10)
                                 }})
                             level_up_users.append(user)
-                    level_up_names = util.sanitize_display_name(channel[0], 0, util.get_display_name(0, level_up_users))
+                    level_up_names = util.sanitize_display_name(channel[0], None, util.get_display_name(None, level_up_users))
                     if level_up_names:
                         i = 1
                         for user in level_up_names[::5]:

--- a/messages.py
+++ b/messages.py
@@ -148,8 +148,10 @@ tag_error = emoji.emojize(':warning: ', use_aliases=True) + 'Insufficient parame
 
 restart_message = emoji.emojize(':arrows_counterclockwise:', use_aliases=True) + ' Restarting...'
 
-banphrased_name = '[Banphrased Name]'
-
 banphrased = '[Banphrased]'
 
-banphrase_api_offline = '[Banphrase API ' + emoji.emojize(':electric_plug:', use_aliases=True) + ']'
+banphrase_api_offline = 'Banphrase API did not send a response back.'
+
+banphrased_name = '[Banphrased Name]'
+
+banphrase_name_api_offline = '[Banphrase API ' + emoji.emojize(':electric_plug:', use_aliases=True) + ']'

--- a/messages.py
+++ b/messages.py
@@ -147,3 +147,9 @@ set_cooldown_error = emoji.emojize(':warning: ', use_aliases=True) + 'Insufficie
 tag_error = emoji.emojize(':warning: ', use_aliases=True) + 'Insufficient parameters - usage: +tag <user> <role>'
 
 restart_message = emoji.emojize(':arrows_counterclockwise:', use_aliases=True) + ' Restarting...'
+
+banphrased_name = '[Banphrased Name]'
+
+banphrased = '[Banphrased]'
+
+banphrase_api_offline = '[Banphrase API ' + emoji.emojize(':electric_plug:', use_aliases=True) + ']'

--- a/schemes.py
+++ b/schemes.py
@@ -33,5 +33,6 @@ CHANNELS = {
     'global_cooldown': 2.5,
     'user_cooldown': 0,
     'message_queued': 0,
-    'raid_events': 1
+    'raid_events': 1,
+    'banphrase_api': ''
 }

--- a/utility.py
+++ b/utility.py
@@ -276,7 +276,7 @@ def check_banphrase(message, channel_name):
 
     banphrase_api =  db(opt.CHANNELS).find_one({'name': channel_name})['banphrase_api']
 
-    if len(banphrase_api) == 0:
+    if not banphrase_api:
         return False
 
     try:

--- a/utility.py
+++ b/utility.py
@@ -284,7 +284,7 @@ def check_banphrase(message, channel_name):
     return response
 
 def sanitize_display_name(channel_name, display_name, display_names = None):
-    if display_name != 0:
+    if display_name:
         try:
             return messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name
         except:

--- a/utility.py
+++ b/utility.py
@@ -279,34 +279,34 @@ def check_banphrase(message, channel_name):
     if not banphrase_api:
         return False
 
-    try:
-        time.sleep(random.uniform(0.1, 1))
-        response = requests.post('https://' + banphrase_api + '/api/v1/banphrases/test', headers=headers, params=params).json()
-        return response
-    except:
-        raise Exception()
+    time.sleep(random.uniform(0.1, 1))
+    response = requests.post('https://' + banphrase_api + '/api/v1/banphrases/test', headers=headers, params=params).json()
+    return response
 
 def sanitize_display_name(channel_name, display_name, display_names = None):
     if display_name != 0:
         try:
             return messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name
         except:
-            return messages.banphrase_api_offline
+            return messages.banphrase_name_api_offline
     elif display_names:
         display_name_list = []
         for display_name in display_names:
             try:
                 display_name_list.append(messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name)
             except:
-                display_name_list.append(messages.banphrase_api_offline)
+                display_name_list.append(messages.banphrase_name_api_offline)
         return display_name_list
 
 def sanitize_message(message, channel):
-    banphrase_api_check = check_banphrase(message, channel)
-    if banphrase_api_check and banphrase_api_check['banned']:
-        phrase = banphrase_api_check['banphrase_data']['phrase']
-        if banphrase_api_check['banphrase_data']['case_sensitive']:
-            message = message.replace(phrase)
-        else:
-            message = message.lower().replace(phrase.lower(), messages.banphrased)
-    return message
+    try:
+        banphrase_api_check = check_banphrase(message, channel)
+        if banphrase_api_check and banphrase_api_check['banned']:
+            phrase = banphrase_api_check['banphrase_data']['phrase']
+            if banphrase_api_check['banphrase_data']['case_sensitive']:
+                message = message.replace(phrase)
+            else:
+                message = re.sub(re.escape(phrase), messages.banphrased, message, flags=re.IGNORECASE)
+        return message
+    except:
+        return messages.banphrase_api_offline

--- a/utility.py
+++ b/utility.py
@@ -283,20 +283,14 @@ def check_banphrase(message, channel_name):
     response = requests.post('https://' + banphrase_api + '/api/v1/banphrases/test', headers=headers, params=params).json()
     return response
 
-def sanitize_display_name(channel_name, display_name, display_names = None):
-    if display_name:
+def sanitize_display_names(channel_name, display_names):
+    display_name_list = []
+    for display_name in display_names:
         try:
-            return messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name
+            display_name_list.append(messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name)
         except:
-            return messages.banphrase_name_api_offline
-    elif display_names:
-        display_name_list = []
-        for display_name in display_names:
-            try:
-                display_name_list.append(messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name)
-            except:
-                display_name_list.append(messages.banphrase_name_api_offline)
-        return display_name_list
+            display_name_list.append(messages.banphrase_name_api_offline)
+    return display_name_list
 
 def sanitize_message(message, channel):
     try:

--- a/utility.py
+++ b/utility.py
@@ -89,6 +89,7 @@ def get_cooldown_bypass_symbol():
         return ' \U000e0000'
 
 def send_message(message, channel):
+    message = sanitize_message(message, channel)
     msg = 'PRIVMSG #' + channel + ' :' + message + get_cooldown_bypass_symbol()
     sock.send((msg + '\r\n').encode('utf-8'))
 
@@ -98,6 +99,7 @@ def queue_message_to_one(message, channel):
     queue_message_lock.acquire()
     db(opt.CHANNELS).update_one_by_name(channel, { '$set': { 'message_queued': 1 } } )
     time.sleep(1.25)
+    message = sanitize_message(message, channel)
     msg = 'PRIVMSG #' + channel + ' :' + message + get_cooldown_bypass_symbol()
     sock.send((msg + '\r\n').encode('utf-8'))
     time.sleep(1)
@@ -178,7 +180,8 @@ def join_channel(current_channel, channel, global_cooldown, user_cooldown):
                 'global_cooldown': global_cooldown,
                 'user_cooldown': user_cooldown,
                 'message_queued': 0,
-                'raid_events': 1
+                'raid_events': 1,
+                'banphrase_api': ''
             }}, upsert=True)
             db(opt.TAGS).update_one(user, {'$set': { 'moderator': 1 } }, upsert=True)
             sock.send(('JOIN #' + channel + '\r\n').encode('utf-8'))
@@ -264,3 +267,46 @@ def tag_user(user, tag, channel):
                 queue_message_to_one(messages.tag_message(get_display_name(user_id), tag), channel)
             else:
                 queue_message_to_one(messages.already_tag_message(get_display_name(user_id), tag), channel)
+
+### Banphrase API ###
+
+def check_banphrase(message, channel_name):
+    headers = { 'User-Agent': 'huwobot (https://huwobot.com/)' }
+    params = (('message', message),)
+
+    banphrase_api =  db(opt.CHANNELS).find_one({'name': channel_name})['banphrase_api']
+
+    if len(banphrase_api) == 0:
+        return False
+
+    try:
+        time.sleep(random.uniform(0.1, 1))
+        response = requests.post('https://' + banphrase_api + '/api/v1/banphrases/test', headers=headers, params=params).json()
+        return response
+    except:
+        raise Exception()
+
+def sanitize_display_name(channel_name, display_name, display_names = None):
+    if display_name != 0:
+        try:
+            return messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name
+        except:
+            return messages.banphrase_api_offline
+    elif display_names:
+        display_name_list = []
+        for display_name in display_names:
+            try:
+                display_name_list.append(messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name)
+            except:
+                display_name_list.append(messages.banphrase_api_offline)
+        return display_name_list
+
+def sanitize_message(message, channel):
+    banphrase_api_check = check_banphrase(message, channel)
+    if banphrase_api_check['banned']:
+        phrase = banphrase_api_check['banphrase_data']['phrase']
+        if banphrase_api_check['banphrase_data']['case_sensitive']:
+            message = message.replace(phrase)
+        else:
+            message = message.lower().replace(phrase.lower(), messages.banphrased)
+    return message

--- a/utility.py
+++ b/utility.py
@@ -303,7 +303,7 @@ def sanitize_display_name(channel_name, display_name, display_names = None):
 
 def sanitize_message(message, channel):
     banphrase_api_check = check_banphrase(message, channel)
-    if banphrase_api_check['banned']:
+    if banphrase_api_check and banphrase_api_check['banned']:
         phrase = banphrase_api_check['banphrase_data']['phrase']
         if banphrase_api_check['banphrase_data']['case_sensitive']:
             message = message.replace(phrase)


### PR DESCRIPTION
Users can timeout the bot with their username. This PR aims to fix that.

It checks on `send_message` & `queue_message_to_one` and for the "level_up_names" field in `raid_event`.

You may have to add "banphrase_api" fields to all channels, but they can remain as empty string: `"banphrase_api":""`.

Here's a list of pajbot channels:
https://pastebin.com/raw/Fdhe9Vt2

Note, add them without `https://` and `/api/v1/banphrases/test`.
So forsen's would be: `"banphrase_api": "forsen.tv"`

Godspeed.