### PR TITLE
Fix on missing banphrase api

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -118,7 +118,7 @@ def raid_event():
                     if level_up_names:
                         i = 1
                         for user in level_up_names[::5]:
-                            util.queue_message_to_one(messages.users_level_up(level_up_names[level_up_names.index(user):5*i]), channel[0])
+                            util.queue_message_to_one(messages.users_level_up(level_up_names[level_up_names.index(user):5*i]), channel[0], True)
                             i += 1
                 db(opt.GENERAL).update_one(0, {'$inc': {
                     'total_experience': experience_gain * len(raid_users),

--- a/utility.py
+++ b/utility.py
@@ -280,15 +280,18 @@ def check_banphrase(message, channel_name):
         return False
 
     time.sleep(random.uniform(0.1, 1))
-    response = requests.post('https://' + banphrase_api + '/api/v1/banphrases/test', headers=headers, params=params).json()
+    response = requests.post('https://' + banphrase_api + '/api/v1/banphrases/test', headers=headers, params=params)
+    response.raise_for_status()
+    response = response.json()
     return response
 
 def sanitize_display_names(channel_name, display_names):
     display_name_list = []
     for display_name in display_names:
         try:
-            display_name_list.append(messages.banphrased_name if check_banphrase(display_name, channel_name)['banned'] else display_name)
-        except:
+            banphrase_api_check = check_banphrase(display_name, channel_name)
+            display_name_list.append(messages.banphrased_name if banphrase_api_check and banphrase_api_check['banned'] else display_name)
+        except requests.exceptions.RequestException:
             display_name_list.append(messages.banphrase_name_api_offline)
     return display_name_list
 
@@ -302,5 +305,5 @@ def sanitize_message(message, channel):
             else:
                 message = re.sub(re.escape(phrase), messages.banphrased, message, flags=re.IGNORECASE)
         return message
-    except:
+    except requests.exceptions.RequestException:
         return messages.banphrase_api_offline


### PR DESCRIPTION
Aha! Today pajbot broke, which meant that the previous PR was put to the test.

And it does look like last PR had a few bugs, sorry about that.

First bug was that on the level up message in channels that do not have a banphrase api, the resulting array would be:
![image](https://user-images.githubusercontent.com/13697809/130525353-7e5a6504-4489-45c9-ac3d-92e9fe686256.png)

For the fix on that I got a few tips to not use bare excepts' so you can catch bugs properly later on if anything was to change with the pajbot api.



The `"fix: users_level_up to send when paj api is off"` commit makes sure the level up message sends an array of `[Banphrase API 🔌], [Banphrase API 🔌], <...> just leveled up! PogChamp` instead of the default `Banphrase API did not send a response back.` if the api is actually down.

I'll make more PRs if I see any more bugs.